### PR TITLE
Refactor: Change port 9100 to port 8080

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,19 +15,19 @@ Uses `tectonic` to run compilation.
 ```
 
 ## Usage
-The server listens on localhost:9100 for POSTs to REST endpoint /latex/fragment
+The server listens on localhost:8080 for POSTs to REST endpoint /latex/fragment
 The expected format of the POST body is: {latex: 'some latex fragment'}
 
 Some example curl commands:
 
 ```
-> curl -d 'latex=Understanding $\boldsymbol{\delta}$-Function' http://localhost:9100/latex/fragment
+> curl -d 'latex=Understanding $\boldsymbol{\delta}$-Function' http://localhost:8080/latex/fragment
 > {"status": "ok"}
 ```
 
 Fail if \boldsymbol is misspelled:
 ```
-> curl -d 'latex=Understanding $\bldsym{\delta}$-Function' http://localhost:9100/latex/fragment
+> curl -d 'latex=Understanding $\bldsym{\delta}$-Function' http://localhost:8080/latex/fragment
 > {"status":"error","message":"Undefined control sequence"}
 ```
 

--- a/src/server/http-server.test.ts
+++ b/src/server/http-server.test.ts
@@ -9,8 +9,8 @@ describe('HTTP Server', () => {
       r.get('/bar', respondWith({ bar: 'foo' }))
       r.get('/foo', respondWith({ foo: 'bar' }))
     })) {
-      await isGETEqual('http://localhost:9100/foo', { foo: 'bar' })
-      await isGETEqual('http://localhost:9100/bar', { bar: 'foo' })
+      await isGETEqual('http://localhost:8080/foo', { foo: 'bar' })
+      await isGETEqual('http://localhost:8080/bar', { bar: 'foo' })
     }
 
   });

--- a/src/server/http-server.ts
+++ b/src/server/http-server.ts
@@ -24,7 +24,7 @@ export async function* withServerGen(
   setup(routes);
 
   // TODO config port
-  const port = 9100;
+  const port = process.env.PORT || 8080;
 
   app.use(routes.routes());
   app.use(routes.allowedMethods());
@@ -95,7 +95,7 @@ export function respondWithHtml(
 // export async function startTestServer(): Promise<Server> {
 //   const app = new Koa();
 
-//   const port = 9100;
+//   const port = process.env.PORT || 8080;
 
 //   const htmlRoutes = htmlRouter();
 

--- a/src/server/rest-api.test.ts
+++ b/src/server/rest-api.test.ts
@@ -21,7 +21,7 @@ describe('REST Endpoints', () => {
   }
   it('should use withServer() and properly shutdown', async () => {
     for await (const __ of withRestServer(latexPackages)) {
-      const url = 'http://localhost:9100/latex/fragment';
+      const url = 'http://localhost:8080/latex/fragment';
       for await (const example of examples) {
         const resp = await axios.post(url, {latex: example});
         const data = resp.data;


### PR DESCRIPTION
Google Cloud Run calls the deployed service on port 8080 by default